### PR TITLE
Label Sequence Bottom Prev & Next Arrows

### DIFF
--- a/static/sass/_lagunita.scss
+++ b/static/sass/_lagunita.scss
@@ -290,6 +290,32 @@ $video-thumb-url: '../themes/lagunita/images/stanford-online-video-thumb.png';
     }
 }
 
+// Previous and Next arrow styling changes
+#course-content .sequence-bottom {
+    li {
+        width: 120px;
+        
+        a {
+            padding: 14px 10px;
+            text-indent: 0;
+        }
+
+        &.prev {
+            a {
+                padding-left: 40px;
+                background-position: 15px 15px !important;
+            }
+        }
+
+        &.next {
+            a {
+                padding-left: 30px;
+                background-position: 95px 15px !important;
+            }
+        }
+    }
+}
+
 // Shib username page
 section.introduction h1.sr {
     min-height: 100px;


### PR DESCRIPTION
Display "Previous" and "Next" arrows in sequence-bottom nav to make it more obvious that they are for unit navigation.

Resolves LE-286

@stvstnfrd 

Before:
![screen shot 2015-04-28 at 11 35 29 am](https://cloud.githubusercontent.com/assets/3364609/7377353/bb4f7534-ed9a-11e4-8476-71235e050cae.png)

After:
![screen shot 2015-04-28 at 11 35 38 am](https://cloud.githubusercontent.com/assets/3364609/7377358/bff9e5d8-ed9a-11e4-90d3-f569df0f058a.png)
