### PR TITLE
Giulio/grade report style fixes

### DIFF
--- a/static/sass/_lagunita.scss
+++ b/static/sass/_lagunita.scss
@@ -318,16 +318,21 @@ $video-thumb-url: '../themes/lagunita/images/stanford-online-video-thumb.png';
     .sequence-nav-button {
         width: 110px;
         text-indent: 0;
-        padding: 6px 7px 8px 7px;
+        padding: 8px 14px;
 
         &.button-previous {
-            padding-left: 29px;
-            background-position: 15px 15px;
+            text-align: left;
+            .icon {
+                margin-right: 15px;
+            }
         }
 
         &.button-next {
-            padding-right: 29px;
-            background-position: 85px 15px;
+            text-align: right;
+
+            .icon {
+                margin-left: 30px;
+            }
         }
     }
 }


### PR DESCRIPTION
@stvstnfrd this is to be merged along with @dcadams' grade-report fixes

Homepage before:
![homepage_before](https://cloud.githubusercontent.com/assets/3364609/9370698/0678363c-4687-11e5-98ac-5b2d12737410.png)

Homepage after:
![homepage_after](https://cloud.githubusercontent.com/assets/3364609/9370699/0fe3428e-4687-11e5-89ba-6cea2155a1c3.png)

Arrows before:
![arrows_before](https://cloud.githubusercontent.com/assets/3364609/9370702/158981d0-4687-11e5-820e-6c808ef75c80.png)

Arrows after:
![arrows_after](https://cloud.githubusercontent.com/assets/3364609/9370705/1bce10f6-4687-11e5-8a20-3fa2d0611ea5.png)
