### PR TITLE
Fix fetch of course title

### DIFF
--- a/templates/courseware/theme-course_about-social_sharing.html
+++ b/templates/courseware/theme-course_about-social_sharing.html
@@ -4,9 +4,9 @@
   from courseware.courses import get_course_about_section
 %>
 
-<a href="http://twitter.com/intent/tweet?text=I+just+registered+for+${course.number}+${get_course_about_section(request, course, 'title')}!+(http://lagunita.stanford.edu)" class="share">		
+<a href="http://twitter.com/intent/tweet?text=I+just+registered+for+${course.number}+${course.display_name_with_default}!+(http://lagunita.stanford.edu)" class="share">
     <i class="fa fa-twitter"></i><span class="sr">${_("Tweet that you've registered for this course")}</span>
 </a>
-<a href="mailto:?subject=Take%20a%20course%20at%20Stanford%20Lagunita!&body=I%20just%20registered%20for%20${course.number}%20${get_course_about_section(request, course, 'title')}+(http://lagunita.stanford.edu)" class="share">		
+<a href="mailto:?subject=Take%20a%20course%20at%20Stanford%20Lagunita!&body=I%20just%20registered%20for%20${course.number}%20${course.display_name_with_default}+(http://lagunita.stanford.edu)" class="share">
     <i class="fa fa-envelope"></i><span class="sr">${_("Email someone to say you've registered for this course")}</span>
 </a>


### PR DESCRIPTION
The course title is now accessible directly from the course object [1].

[1] https://github.com/edx/edx-platform/pull/10841