### PR TITLE
Make staff/history modals behave in all browsers

### DIFF
--- a/static/sass/_lagunita.scss
+++ b/static/sass/_lagunita.scss
@@ -344,6 +344,18 @@ section.introduction h1.sr {
     min-height: 100px;
 }
 
+// Modal styling
+#seq_content .vert-mod {
+    section.modal.staff-modal,
+    section.modal.history-modal {
+        left: 0 !important;
+        top: 0 !important;
+        width: 90% !important;
+        height: 85% !important;
+        margin: 5% !important;
+    }
+}
+
 //-----------------
 // Footer Styling
 //-----------------


### PR DESCRIPTION
Before:
![screen shot 2017-01-27 at 11 28 57 am](https://cloud.githubusercontent.com/assets/3364609/22384582/dfeacd6c-e483-11e6-86b7-9cf7bb9551ed.png)

After:
![screen shot 2017-01-27 at 11 29 04 am](https://cloud.githubusercontent.com/assets/3364609/22384589/e4eb1880-e483-11e6-8156-86728827157c.png)

Offending styling:
![screen shot 2017-01-30 at 3 25 59 pm](https://cloud.githubusercontent.com/assets/3364609/22446245/7ac24b20-e700-11e6-96fb-70c6b5daa78b.png)
